### PR TITLE
🚀[Feature]: Return new version object if passing empty string as version

### DIFF
--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -27,3 +27,4 @@ jobs:
         uses: super-linter/super-linter@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          VALIDATE_JSCPD: false

--- a/src/public/New-PSSemVer.ps1
+++ b/src/public/New-PSSemVer.ps1
@@ -69,6 +69,9 @@
             return [PSSemVer]::New($Major, $Minor, $Patch, $Prerelease, $BuildMetadata)
         }
         'String' {
+            if ([string]::IsNullOrEmptySpace($Version)) {
+                $Version = '0.0.0'
+            }
             return [PSSemVer]::New($Version)
         }
     }

--- a/src/public/New-PSSemVer.ps1
+++ b/src/public/New-PSSemVer.ps1
@@ -69,7 +69,7 @@
             return [PSSemVer]::New($Major, $Minor, $Patch, $Prerelease, $BuildMetadata)
         }
         'String' {
-            if ([string]::IsNullOrEmptySpace($Version)) {
+            if ([string]::IsNullOrEmpty($Version)) {
                 $Version = '0.0.0'
             }
             return [PSSemVer]::New($Version)

--- a/src/public/New-PSSemVer.ps1
+++ b/src/public/New-PSSemVer.ps1
@@ -61,6 +61,7 @@
             Mandatory,
             ParameterSetName = 'String'
         )]
+        [AllowEmptyString()]
         [string] $Version
     )
 

--- a/tests/PSSemVer.Tests.ps1
+++ b/tests/PSSemVer.Tests.ps1
@@ -139,6 +139,14 @@ Describe 'PSSemVer' {
         It "Throws on [PSSemVer]'1.0.0-beta!1'" {
             { [PSSemVer]'1.0.0-beta!1' } | Should -Throw
         }
+        It "Returns an initial version of '0.0.0' passing empty -Version ''" {
+            $PSSemVer = New-PSSemVer
+            $PSSemVer.Major | Should -Be 0
+            $PSSemVer.Minor | Should -Be 0
+            $PSSemVer.Patch | Should -Be 0
+            $PSSemVer.Prerelease | Should -BeNullOrEmpty
+            $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
+        }
     }
 
     Describe 'Class: ToString()' {

--- a/tests/PSSemVer.Tests.ps1
+++ b/tests/PSSemVer.Tests.ps1
@@ -410,23 +410,23 @@ Describe 'PSSemVer' {
             $PSSemVer.Prerelease | Should -Be 'alpha.1'
             $PSSemVer.BuildMetadata | Should -Be '001'
         }
-        It "Parses 'v-1.2.3-alpha.1+001' to PSSemVer" {
-            $PSSemVer = [PSSemVer]::Parse('v-1.2.3-alpha.1+001')
+        It "Parses 'v-2.3.4-alpha.2+001' to PSSemVer" {
+            $PSSemVer = [PSSemVer]::Parse('v-2.3.4-alpha.2+001')
             $PSSemVer.Prefix | Should -Be 'v'
-            $PSSemVer.Major | Should -Be 1
-            $PSSemVer.Minor | Should -Be 2
-            $PSSemVer.Patch | Should -Be 3
-            $PSSemVer.Prerelease | Should -Be 'alpha.1'
+            $PSSemVer.Major | Should -Be 2
+            $PSSemVer.Minor | Should -Be 3
+            $PSSemVer.Patch | Should -Be 4
+            $PSSemVer.Prerelease | Should -Be 'alpha.2'
             $PSSemVer.BuildMetadata | Should -Be '001'
         }
-        It "Parses 'v1.2.3-alpha.1+001' to PSSemVer" {
-            $PSSemVer = [PSSemVer]::Parse('v1.2.3-alpha.1+001')
+        It "Parses 'v3.4.5-alpha.3+002' to PSSemVer" {
+            $PSSemVer = [PSSemVer]::Parse('v3.4.5-alpha.3+002')
             $PSSemVer.Prefix | Should -Be 'v'
-            $PSSemVer.Major | Should -Be 1
-            $PSSemVer.Minor | Should -Be 2
-            $PSSemVer.Patch | Should -Be 3
-            $PSSemVer.Prerelease | Should -Be 'alpha.1'
-            $PSSemVer.BuildMetadata | Should -Be '001'
+            $PSSemVer.Major | Should -Be 3
+            $PSSemVer.Minor | Should -Be 4
+            $PSSemVer.Patch | Should -Be 5
+            $PSSemVer.Prerelease | Should -Be 'alpha.3'
+            $PSSemVer.BuildMetadata | Should -Be '002'
         }
         It "Parses 'v10.2.3-alpha.1+001' to PSSemVer" {
             $PSSemVer = [PSSemVer]::Parse('v10.2.3-alpha.1+001')

--- a/tests/PSSemVer.Tests.ps1
+++ b/tests/PSSemVer.Tests.ps1
@@ -44,6 +44,14 @@ Describe 'PSSemVer' {
             $PSSemVer.Prerelease | Should -BeNullOrEmpty
             $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
         }
+        It "New-PSSemVer -Version '' => '0.0.0'" {
+            $PSSemVer = New-PSSemVer -Version ''
+            $PSSemVer.Major | Should -Be 0
+            $PSSemVer.Minor | Should -Be 0
+            $PSSemVer.Patch | Should -Be 0
+            $PSSemVer.Prerelease | Should -BeNullOrEmpty
+            $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
+        }
     }
 
     Describe 'Function: ConvertTo-PSSemVer' {
@@ -138,14 +146,6 @@ Describe 'PSSemVer' {
 
         It "Throws on [PSSemVer]'1.0.0-beta!1'" {
             { [PSSemVer]'1.0.0-beta!1' } | Should -Throw
-        }
-        It "Returns an initial version of '0.0.0' passing empty -Version ''" {
-            $PSSemVer = New-PSSemVer -Version ''
-            $PSSemVer.Major | Should -Be 0
-            $PSSemVer.Minor | Should -Be 0
-            $PSSemVer.Patch | Should -Be 0
-            $PSSemVer.Prerelease | Should -BeNullOrEmpty
-            $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
         }
     }
 

--- a/tests/PSSemVer.Tests.ps1
+++ b/tests/PSSemVer.Tests.ps1
@@ -140,7 +140,7 @@ Describe 'PSSemVer' {
             { [PSSemVer]'1.0.0-beta!1' } | Should -Throw
         }
         It "Returns an initial version of '0.0.0' passing empty -Version ''" {
-            $PSSemVer = New-PSSemVer
+            $PSSemVer = New-PSSemVer -Version ''
             $PSSemVer.Major | Should -Be 0
             $PSSemVer.Minor | Should -Be 0
             $PSSemVer.Patch | Should -Be 0

--- a/tests/PSSemVer.Tests.ps1
+++ b/tests/PSSemVer.Tests.ps1
@@ -36,19 +36,19 @@ Describe 'PSSemVer' {
             $PSSemVer.Prerelease | Should -BeNullOrEmpty
             $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
         }
-        It "New-PSSemVer -Version '1.2.3' => '1.2.3'" {
-            $PSSemVer = New-PSSemVer -Version '1.2.3'
-            $PSSemVer.Major | Should -Be 1
-            $PSSemVer.Minor | Should -Be 2
-            $PSSemVer.Patch | Should -Be 3
-            $PSSemVer.Prerelease | Should -BeNullOrEmpty
-            $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
-        }
         It "New-PSSemVer -Version '' => '0.0.0'" {
             $PSSemVer = New-PSSemVer -Version ''
             $PSSemVer.Major | Should -Be 0
             $PSSemVer.Minor | Should -Be 0
             $PSSemVer.Patch | Should -Be 0
+            $PSSemVer.Prerelease | Should -BeNullOrEmpty
+            $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
+        }
+        It "New-PSSemVer -Version '1.2.3' => '1.2.3'" {
+            $PSSemVer = New-PSSemVer -Version '1.2.3'
+            $PSSemVer.Major | Should -Be 1
+            $PSSemVer.Minor | Should -Be 2
+            $PSSemVer.Patch | Should -Be 3
             $PSSemVer.Prerelease | Should -BeNullOrEmpty
             $PSSemVer.BuildMetadata | Should -BeNullOrEmpty
         }


### PR DESCRIPTION
## Description

- When passing an empty string in the version parameter, a new version object is returned of version '0.0.0'. 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
