### PR TITLE
🩹 [Patch]: Best effort support PowerShell v5.1

### DIFF
--- a/src/manifest.psd1
+++ b/src/manifest.psd1
@@ -1,0 +1,3 @@
+﻿@{
+    PowerShellVersion = "5.1"
+}


### PR DESCRIPTION
## Description

This pull request includes a small change to the `src/manifest.psd1` file. The change specifies the required PowerShell version for the script.

* [`src/manifest.psd1`](diffhunk://#diff-89820c99acb3b881e314c7e358eea621a8687cb4e0c687f541b9dcc9f30cc5dcR1-R3): Added `PowerShellVersion` key with the value "5.1".
* Fixes #29 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
